### PR TITLE
Sprint 3 Increment 13: Handle duplicate URLs with status 409

### DIFF
--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -51,9 +51,6 @@ func TestSaveURLToDatabaseStorage(t *testing.T) {
 	theStorage := getDatabaseStorage(t)
 	db := theStorage.DB
 
-	theStorage.Set(ctx, "foo", "https://practicum.yandex.ru/", "user1") // nolint: errcheck
-	assert.Equal(t, "https://practicum.yandex.ru/", getRowForShortID(db, "foo").LongURL)
-	// Можем перезаписать
 	theStorage.Set(ctx, "foo", "https://go.dev/", "user1") // nolint: errcheck
 	assert.Equal(t, "https://go.dev/", getRowForShortID(db, "foo").LongURL)
 
@@ -131,8 +128,8 @@ func TestGetUserURLsFromDatabaseStorage(t *testing.T) {
 	theStorage.Set(ctx, "foo", "https://practicum.yandex.ru/", user1) // nolint: errcheck
 	theStorage.Set(ctx, "bar", "https://go.dev/", user1)              // nolint: errcheck
 	theStorage.Set(ctx, "foo", "https://google.com/", user2)          // nolint: errcheck
-	theStorage.Set(ctx, "baz", "https://google.com/", user2)          // nolint: errcheck
-	theStorage.Set(ctx, "ham", "https://google.com/", "")             // nolint: errcheck
+	theStorage.Set(ctx, "baz", "https://exampe.com/", user2)          // nolint: errcheck
+	theStorage.Set(ctx, "ham", "https://wikipedia.org/", "")          // nolint: errcheck
 
 	user1Items, _ := theStorage.GetURLsByUserID(ctx, user1)
 	assert.Len(t, user1Items, 2)

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -1,5 +1,8 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+)
 
 var ErrURLNotFound = errors.New("URL not found in the storage")
+var ErrURLAlreadyExists = errors.New("URL already exists in the storage")

--- a/storage/file.go
+++ b/storage/file.go
@@ -48,9 +48,9 @@ func NewFileURLStorerBackend(filename string) (*FileURLStorerBackend, error) {
 	return &FileURLStorerBackend{filename, cache}, nil
 }
 
-func (backend FileURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) error {
+func (backend FileURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) (string, error) {
 	backend.cache[shortURLID] = FileURLItem{longURL, userID}
-	return nil
+	return shortURLID, nil
 }
 
 func (backend FileURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -3,7 +3,7 @@ package storage
 import "context"
 
 type URLStorer interface {
-	Set(context.Context, string, string, string) error
+	Set(context.Context, string, string, string) (string, error)
 	Get(context.Context, string) (string, error)
 	GetURLsByUserID(context.Context, string) (map[string]string, error)
 	SaveBatch(context.Context, []BatchItem) error

--- a/storage/locmem.go
+++ b/storage/locmem.go
@@ -16,9 +16,9 @@ func NewLocmemURLStorerBackend() *LocmemURLStorerBackend {
 	return &LocmemURLStorerBackend{Storage: storage}
 }
 
-func (backend LocmemURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) error {
+func (backend LocmemURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) (string, error) {
 	backend.Storage[shortURLID] = LocURLItem{longURL, userID}
-	return nil
+	return shortURLID, nil
 }
 
 func (backend LocmemURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {


### PR DESCRIPTION
Добавлена обработка дублей ссылок, присылаемых в эндпоинты `POST /` и `POST /api/shorten`. Для ранее сокращенных ссылок теперь возвращается статус 409 и старая ссылка