### PR TITLE
Sprint 4: handle url batch deletions

### DIFF
--- a/.github/workflows/shortenertest.yml
+++ b/.github/workflows/shortenertest.yml
@@ -51,8 +51,7 @@ jobs:
         if: always()
         run: |
           shortenertest -test.v -test.run=^TestIteration1$ \
-              -binary-path=cmd/shortener/shortener \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -binary-path=cmd/shortener/shortener
 
       - name: "Code increment #2"
         if: always()
@@ -69,8 +68,7 @@ jobs:
         run: |
           shortenertest -test.v -test.run=^TestIteration4$ \
               -source-path=. \
-              -binary-path=cmd/shortener/shortener \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -binary-path=cmd/shortener/shortener
 
       - name: "Code increment #5"
         if: always()
@@ -81,8 +79,7 @@ jobs:
               -binary-path=cmd/shortener/shortener \
               -server-host=$SERVER_HOST \
               -server-port=$SERVER_PORT \
-              -server-base-url="http://$SERVER_HOST:$SERVER_PORT" \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -server-base-url="http://$SERVER_HOST:$SERVER_PORT"
 
       - name: "Code increment #6"
         if: always()
@@ -93,8 +90,7 @@ jobs:
               -binary-path=cmd/shortener/shortener \
               -server-port=$SERVER_PORT \
               -file-storage-path=$TEMP_FILE \
-              -source-path=. \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -source-path=.
 
       - name: "Code increment #7"
         if: always()
@@ -105,24 +101,21 @@ jobs:
               -binary-path=cmd/shortener/shortener \
               -server-port=$SERVER_PORT \
               -file-storage-path=$TEMP_FILE \
-              -source-path=. \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -source-path=.
 
       - name: "Code increment #8"
         if: always()
         run: |
           shortenertest -test.v -test.run=^TestIteration8$ \
               -source-path=. \
-              -binary-path=cmd/shortener/shortener \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -binary-path=cmd/shortener/shortener
 
       - name: "Code increment #9"
         if: always()
         run: |
           shortenertest -test.v -test.run=^TestIteration9$ \
               -source-path=. \
-              -binary-path=cmd/shortener/shortener \
-              -database-dsn='postgres://postgres:postgres@postgres:5432/praktikum?sslmode=disable'
+              -binary-path=cmd/shortener/shortener
 
       - name: "Code increment #10"
         if: always()

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.11.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.17
 require (
 	github.com/caarlos0/env/v6 v6.9.1
 	github.com/go-chi/chi/v5 v5.0.7
+	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v4 v4.15.0
+	github.com/lib/pq v1.10.2
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.11.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -14,6 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v4"
+	"github.com/sergeii/practikum-go-url-shortener/pkg/random"
+
 	"github.com/sergeii/practikum-go-url-shortener/internal/app"
 	"github.com/sergeii/practikum-go-url-shortener/internal/handlers"
 	"github.com/sergeii/practikum-go-url-shortener/internal/middleware"
@@ -39,7 +42,6 @@ func setAuthCookie(r *http.Request, secretKey []byte, userID string) *http.Cooki
 	return cookie
 }
 
-// nolint:unparam
 func prepareTestServer(t *testing.T, overrides ...app.Override) (*httptest.Server, *app.App) {
 	var fileStoragePath string
 	// для того чтобы тесты не мешали друг другу при установленной env-переменной FILE_STORAGE_PATH
@@ -54,20 +56,37 @@ func prepareTestServer(t *testing.T, overrides ...app.Override) (*httptest.Serve
 		}
 		return nil
 	})
-	shorterner, err := app.New(overrides...)
+	// аналогично для DATABASE_DSN подставляем рандомно сгенерированную схему (search path),
+	// предварительно ее создав, используя подключение к бд через оригинальный dsn
+	overrides = append(overrides, func(cfg *app.Config) error {
+		if cfg.DatabaseDSN != "" {
+			schema := random.String(5, "abcdefghijklmnopqrstuvwxyz")
+			db, err := pgx.Connect(context.TODO(), cfg.DatabaseDSN)
+			if err != nil {
+				return err
+			}
+			defer db.Close(context.TODO())
+			if _, err := db.Exec(context.TODO(), "CREATE SCHEMA "+schema); err != nil {
+				return err
+			}
+			cfg.DatabaseDSN += "?search_path=" + schema
+		}
+		return nil
+	})
+	shortener, err := app.New(overrides...)
 	if err != nil {
 		panic(err)
 	}
-	ts := httptest.NewServer(router.New(shorterner))
+	ts := httptest.NewServer(router.New(shortener))
 	t.Cleanup(func() {
 		if fileStoragePath != "" {
 			os.Remove(fileStoragePath)
 		}
 	})
 	t.Cleanup(ts.Close)
-	t.Cleanup(shorterner.Close)
-	t.Cleanup(shorterner.Cleanup)
-	return ts, shorterner
+	t.Cleanup(shortener.Close)
+	t.Cleanup(shortener.Cleanup)
+	return ts, shortener
 }
 
 func doTestRequest(t *testing.T, ts *httptest.Server, method, path string, body io.Reader) (*http.Response, string) {
@@ -105,7 +124,7 @@ func TestShortenAndExpandAnyLengthURLs(t *testing.T) {
 
 		// Получаем относительный url, состоящий из 7 символов, и пробуем перейти по нему
 		parsed, _ := url.Parse(body)
-		assert.Len(t, strings.Trim(parsed.Path, "/"), 7)
+		assert.Len(t, strings.Trim(parsed.Path, "/"), 11)
 		resp, _ = doTestRequest(t, ts, http.MethodGet, parsed.Path, nil)
 		resp.Body.Close()
 		// Получем ожидаем редирект на оригинальный url
@@ -244,7 +263,7 @@ func TestShortenEndpointSupportsCustomizableBaseURL(t *testing.T) {
 			shortener.Config.BaseURL = *testBaseURL
 			resp, body := doTestRequest(t, ts, http.MethodPost, "/", strings.NewReader("https://ya.ru/"))
 			resp.Body.Close()
-			assert.Equal(t, tt.want, body[:len(body)-7])
+			assert.Equal(t, tt.want, body[:len(body)-11])
 		})
 	}
 }
@@ -277,7 +296,7 @@ func TestAPIShortenAndExpandURLs(t *testing.T) {
 		var resultJSON ShortenResultBody
 		json.Unmarshal([]byte(body), &resultJSON) // nolint:errcheck
 		parsed, _ := url.Parse(resultJSON.Result)
-		assert.Len(t, strings.Trim(parsed.Path, "/"), 7)
+		assert.Len(t, strings.Trim(parsed.Path, "/"), 11)
 		resp, _ = doTestRequest(t, ts, http.MethodGet, parsed.Path, nil)
 		resp.Body.Close()
 		// Получем ожидаем редирект на оригинальный url
@@ -286,11 +305,11 @@ func TestAPIShortenAndExpandURLs(t *testing.T) {
 	}
 }
 
-func TestAPIShortenEndpointHandlesDuplicateURLs(t *testing.T) {
+func TestAPIShortenEndpointHandlesExistingURLs(t *testing.T) {
 	var resultJSON1, resultJSON2 handlers.APIShortenResult
 
-	ts, shorterner := prepareTestServer(t)
-	if shorterner.DB == nil {
+	ts, shortener := prepareTestServer(t)
+	if shortener.DB == nil {
 		t.Skip("Skipping test because it requires db")
 	}
 
@@ -410,6 +429,34 @@ func TestAPIShortenEndpointRequiresValidJSON(t *testing.T) {
 	}
 }
 
+func TestShortenAndExpandEndpointHandleDeletedURLs(t *testing.T) {
+	ctx := context.TODO()
+	ts, shortener := prepareTestServer(t)
+
+	shortener.Storage.Set(ctx, "go", "https://go.dev/", "user1") // nolint: errcheck
+	shortener.Storage.Set(ctx, "ya", "https://ya.ru/", "user1")  // nolint: errcheck
+
+	shortener.Storage.DeleteUserURLs(context.TODO(), "user1", "go") // nolint: errcheck
+
+	resp, _ := doTestRequest(t, ts, http.MethodGet, "/ya", nil)
+	resp.Body.Close()
+	assert.Equal(t, 307, resp.StatusCode)
+
+	resp, _ = doTestRequest(t, ts, http.MethodGet, "/go", nil)
+	resp.Body.Close()
+	assert.Equal(t, 410, resp.StatusCode)
+
+	// удаленный url можно снова сократить
+	resp, _ = doTestRequest(t, ts, http.MethodPost, "/", strings.NewReader("https://go.dev/"))
+	resp.Body.Close()
+	assert.Equal(t, 201, resp.StatusCode)
+
+	// а неудаленный - нельзя
+	resp, _ = doTestRequest(t, ts, http.MethodPost, "/", strings.NewReader("https://ya.ru/"))
+	resp.Body.Close()
+	assert.Equal(t, 409, resp.StatusCode)
+}
+
 func TestExpandEndpointRequiresShortURLID(t *testing.T) {
 	ts, _ := prepareTestServer(t)
 	resp, _ := doTestRequest(t, ts, http.MethodGet, "/", nil)
@@ -444,8 +491,8 @@ func TestExpandEndpointRequiresProperID(t *testing.T) {
 		},
 	}
 
-	ts, shorterner := prepareTestServer(t)
-	shorterner.Storage.Set(context.TODO(), "gogogo", "https://go.dev/", "user1") // nolint: errcheck
+	ts, shortener := prepareTestServer(t)
+	shortener.Storage.Set(context.TODO(), "gogogo", "https://go.dev/", "user1") // nolint: errcheck
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -462,30 +509,41 @@ func TestExpandEndpointRequiresProperID(t *testing.T) {
 }
 
 func TestSetAndGetUserURLS(t *testing.T) {
-	ts, shorterner := prepareTestServer(t)
+	ts, shortener := prepareTestServer(t)
 	testURLs := []string{"https://ya.ru", "https://go.dev/"}
-	authCookie := setAuthCookie(nil, shorterner.SecretKey, "user1")
+	authCookie := setAuthCookie(nil, shortener.SecretKey, "user1")
 	for _, testURL := range testURLs {
-		req, _ := http.NewRequest("POST", ts.URL+"/", strings.NewReader(testURL))
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(testURL))
 		req.AddCookie(authCookie)
 		resp, _ := http.DefaultClient.Do(req)
 		resp.Body.Close()
 		assert.Equal(t, 201, resp.StatusCode)
 	}
 
-	req, _ := http.NewRequest("GET", ts.URL+"/api/user/urls", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/user/urls", nil)
 	req.AddCookie(authCookie)
 	resp, _ := http.DefaultClient.Do(req)
 	body, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	jsonItems := make([]handlers.APIUserURLItem, 0)
 	json.Unmarshal(body, &jsonItems) // nolint:errcheck
+	shortUserIDs := make([]string, 0)
 	longUserURLs := make([]string, 0)
 	for _, item := range jsonItems {
+		parsed, _ := url.Parse(item.ShortURL)
+		shortUserIDs = append(shortUserIDs, parsed.Path[1:])
 		longUserURLs = append(longUserURLs, item.OriginalURL)
 	}
 	assert.ElementsMatch(t, testURLs, longUserURLs)
 	assert.Equal(t, 200, resp.StatusCode)
+
+	// после удаления всех ссылок эндпоинт вернет 204
+	shortener.Storage.DeleteUserURLs(context.TODO(), "user1", shortUserIDs...) // nolint:errcheck
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/user/urls", nil)
+	req.AddCookie(authCookie)
+	resp, _ = http.DefaultClient.Do(req)
+	resp.Body.Close()
+	assert.Equal(t, 204, resp.StatusCode)
 }
 
 func TestGetUserURLs(t *testing.T) {
@@ -517,16 +575,16 @@ func TestGetUserURLs(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	ts, shorterner := prepareTestServer(t)
-	shorterner.Storage.Set(ctx, "go", "https://go.dev/", "user1")         // nolint: errcheck
-	shorterner.Storage.Set(ctx, "ya", "https://ya.ru/", "user1")          // nolint: errcheck
-	shorterner.Storage.Set(ctx, "imdb", "https://www.imdb.com/", "user2") // nolint: errcheck
+	ts, shortener := prepareTestServer(t)
+	shortener.Storage.Set(ctx, "go", "https://go.dev/", "user1")         // nolint: errcheck
+	shortener.Storage.Set(ctx, "ya", "https://ya.ru/", "user1")          // nolint: errcheck
+	shortener.Storage.Set(ctx, "imdb", "https://www.imdb.com/", "user2") // nolint: errcheck
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", ts.URL+"/api/user/urls", nil)
+			req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/user/urls", nil)
 			if tt.userID != "" {
-				setAuthCookie(req, shorterner.SecretKey, tt.userID)
+				setAuthCookie(req, shortener.SecretKey, tt.userID)
 			}
 			resp, _ := http.DefaultClient.Do(req)
 			body, _ := ioutil.ReadAll(resp.Body)
@@ -628,4 +686,106 @@ func TestAPIShortenBatchNoItemsToProcess(t *testing.T) {
 	resp, _ := doTestRequest(t, ts, http.MethodPost, "/api/shorten/batch", bytes.NewReader(reqJSON))
 	resp.Body.Close()
 	require.Equal(t, 400, resp.StatusCode)
+}
+
+func TestAPIDeleteUserURLs(t *testing.T) {
+	ctx := context.TODO()
+	ts, shortener := prepareTestServer(t)
+
+	shortener.Storage.Set(ctx, "wiki", "https://wikipedia.org/", "u1")      // nolint: errcheck
+	shortener.Storage.Set(ctx, "go", "https://go.dev/", "u1")               // nolint: errcheck
+	shortener.Storage.Set(ctx, "foo", "https://example.com/", "u2")         // nolint: errcheck
+	shortener.Storage.Set(ctx, "ya", "https://ya.ru", "u3")                 // nolint: errcheck
+	shortener.Storage.Set(ctx, "bar", "https://practicum.yandex.ru/", "u1") // nolint: errcheck
+
+	authCookie := setAuthCookie(nil, shortener.SecretKey, "u1")
+	reqJSON, _ := json.Marshal([]string{"wiki", "go", "foo", "ya", "bar", "unknown"}) // nolint:errchkjson
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/user/urls", bytes.NewReader(reqJSON))
+	req.AddCookie(authCookie)
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+	assert.Equal(t, 202, resp.StatusCode)
+
+	expected := map[string]int{
+		"wiki": 410,
+		"go":   410,
+		"bar":  410,
+		"foo":  307, // нельзя удалять чужие ссылки
+		"ya":   307, // тоже
+	}
+	for shortID, wantStatus := range expected {
+		resp, _ := doTestRequest(t, ts, http.MethodGet, "/"+shortID, nil)
+		resp.Body.Close()
+		assert.Equal(t, wantStatus, resp.StatusCode)
+	}
+}
+
+func TestAPIDeleteUserURLsHandleBadRequest(t *testing.T) {
+	ts, _ := prepareTestServer(t)
+
+	tests := []struct {
+		name  string
+		body  string
+		isErr bool
+	}{
+		{
+			name:  "positive case",
+			body:  `["foobar"]`,
+			isErr: false,
+		},
+		{
+			name:  "positive case - empty array",
+			body:  `[]`,
+			isErr: false,
+		},
+		{
+			name:  "empty body",
+			body:  ``,
+			isErr: true,
+		},
+		{
+			name:  "wrong type body",
+			body:  `{"key": "value"}`,
+			isErr: true,
+		},
+		{
+			name:  "wrong type array",
+			body:  `[100500]`,
+			isErr: true,
+		},
+		{
+			name:  "invalid json",
+			body:  `]1[`,
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, _ := doTestRequest(t, ts, http.MethodDelete, "/api/user/urls", strings.NewReader(tt.body))
+			resp.Body.Close()
+			if tt.isErr {
+				assert.Equal(t, 400, resp.StatusCode)
+			} else {
+				assert.Equal(t, 202, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestAPIDeleteUserURLsQueueIsFullError(t *testing.T) {
+	// эмулируем полную очередь, заблокировав навечно запись в канал из-за отсутствия воркеров
+	ts, shortener := prepareTestServer(t, func(cfg *app.Config) error {
+		cfg.BackgroundWorkerConcurrency = 0
+		return nil
+	})
+
+	shortener.Storage.Set(context.TODO(), "wiki", "https://wikipedia.org/", "u1") // nolint: errcheck
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/user/urls", strings.NewReader(`["wiki"]`))
+	authCookie := setAuthCookie(nil, shortener.SecretKey, "u1")
+	req.AddCookie(authCookie)
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+	assert.Equal(t, 503, resp.StatusCode)
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -1,0 +1,14 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/sergeii/practikum-go-url-shortener/pkg/background"
+	"github.com/sergeii/practikum-go-url-shortener/storage"
+)
+
+func DeleteUserURLs(store storage.URLStorer, userID string, shortIDs ...string) background.Job {
+	return background.NewJob("delete user URLs", func(ctx context.Context) error {
+		return store.DeleteUserURLs(ctx, userID, shortIDs...)
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -21,13 +21,13 @@ func New(theApp *app.App) chi.Router {
 	router.Use(middleware.Recoverer)
 	router.Route("/", func(r chi.Router) {
 		r.Post("/", handler.ShortenURL)
-		r.Get("/user/urls", handler.GetUserURLs)
 		r.Get("/ping", handler.Ping)
 		r.Get("/{slug:[a-z0-9]+}", handler.ExpandURL)
 	})
 	router.Route("/api", func(r chi.Router) {
 		r.Post("/shorten", handler.APIShortenURL)
 		r.Post("/shorten/batch", handler.APIShortenBatch)
+		r.Get("/user/urls", handler.GetUserURLs)
 	})
 	return router
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -22,12 +22,13 @@ func New(theApp *app.App) chi.Router {
 	router.Route("/", func(r chi.Router) {
 		r.Post("/", handler.ShortenURL)
 		r.Get("/ping", handler.Ping)
-		r.Get("/{slug:[a-z0-9]+}", handler.ExpandURL)
+		r.Get("/{slug:[a-zA-Z0-9_-]+}", handler.ExpandURL)
 	})
 	router.Route("/api", func(r chi.Router) {
 		r.Post("/shorten", handler.APIShortenURL)
 		r.Post("/shorten/batch", handler.APIShortenBatch)
 		r.Get("/user/urls", handler.GetUserURLs)
+		r.Delete("/user/urls", handler.DeleteUserURLs)
 	})
 	return router
 }

--- a/pkg/background/background.go
+++ b/pkg/background/background.go
@@ -1,0 +1,148 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var ErrAddJobTimeout = errors.New("failed to add new job in time")
+
+const queueBufferMultiplier = 2
+
+type PoolConfig struct {
+	Concurrency   int
+	DoJobTimeout  time.Duration
+	AddJobTimeout time.Duration
+}
+
+type JobFunc func(context.Context) error
+
+type Job struct {
+	ID   string
+	Name string
+	do   JobFunc
+}
+
+type JobResult struct {
+	Job Job
+	Err error
+}
+
+func NewJob(name string, jobFunc JobFunc) Job {
+	return Job{
+		ID:   uuid.New().String(),
+		Name: name,
+		do:   jobFunc,
+	}
+}
+
+func (job Job) Do(ctx context.Context) JobResult {
+	maybeErr := job.do(ctx)
+	return JobResult{Job: job, Err: maybeErr}
+}
+
+type Worker struct {
+	JobTimeout time.Duration
+}
+
+func (worker Worker) Work(ctx context.Context, job Job) JobResult {
+	ctx, cancel := context.WithTimeout(ctx, worker.JobTimeout)
+	defer cancel()
+	// хотя мы и передаем контекст с таймайуом мы не можем гарантировать
+	// что джоб вовремя остановится, поэтому запускаем ее в горутине и сами отслеживаем время выполнения
+	resultCh := make(chan JobResult)
+	go func() {
+		log.Printf("starting job %s [%s]", job.Name, job.ID)
+		resultCh <- job.Do(ctx)
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("deadline exceeded for job %s [%s]", job.Name, job.ID)
+			return JobResult{Job: job, Err: ctx.Err()}
+		case result := <-resultCh:
+			log.Printf("finished job %s [%s]; err? %v", job.Name, job.ID, result.Err)
+			return result
+		}
+	}
+}
+
+type Pool struct {
+	queue chan Job
+	cfg   PoolConfig
+	done  chan struct{}
+}
+
+func NewPool(cfg PoolConfig) *Pool {
+	done := make(chan struct{})
+	queue := make(chan Job, cfg.Concurrency*queueBufferMultiplier)
+	results := make(chan JobResult, cfg.Concurrency*queueBufferMultiplier)
+	pool := Pool{
+		done:  done,
+		cfg:   cfg,
+		queue: queue,
+	}
+
+	// инициализируем воркеров и управляем каналами в отдельной горутине
+	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		for i := 0; i < cfg.Concurrency; i++ {
+			pool.addWorker(ctx, queue, results)
+		}
+		<-done
+		cancel()
+		close(queue)
+		close(results)
+	}()
+
+	// читаем из канала с результами исполнения джобов и пишем их статус в лог
+	go func() {
+		for result := range results {
+			if result.Err != nil {
+				log.Printf("job %s [%s] returned an error: %s", result.Job.Name, result.Job.ID, result.Err)
+			} else {
+				log.Printf("job %s [%s] succeeded", result.Job.Name, result.Job.ID)
+			}
+		}
+	}()
+
+	return &pool
+}
+
+func (pool *Pool) Add(ctx context.Context, job Job) error {
+	ctx, cancel := context.WithTimeout(ctx, pool.cfg.AddJobTimeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		log.Printf("failed to add job %s [%s] due to blocked queue", job.Name, job.ID)
+		return ErrAddJobTimeout
+	case pool.queue <- job:
+		log.Printf("enqueued job %s [%s]", job.Name, job.ID)
+		return nil
+	}
+}
+
+func (pool *Pool) Close() {
+	close(pool.done)
+}
+
+func (pool *Pool) addWorker(ctx context.Context, queue <-chan Job, results chan<- JobResult) *Worker {
+	worker := Worker{JobTimeout: pool.cfg.DoJobTimeout}
+	go func() {
+		for {
+			select {
+			case job := <-queue:
+				log.Printf("obtained new job %s [%s] from queue", job.Name, job.ID)
+				results <- worker.Work(ctx, job)
+			case <-ctx.Done():
+				log.Printf("worker exited due to canceled context")
+				return
+			}
+		}
+	}()
+	return &worker
+}

--- a/pkg/background/background_test.go
+++ b/pkg/background/background_test.go
@@ -1,0 +1,42 @@
+package background_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sergeii/practikum-go-url-shortener/pkg/background"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackgroundJobProcessing(t *testing.T) {
+	numbers := make([]int, 0)
+	ch := make(chan int, 100)
+	pool := background.NewPool(background.PoolConfig{
+		Concurrency:   5,
+		DoJobTimeout:  time.Millisecond * 500,
+		AddJobTimeout: time.Second,
+	})
+	for i := 1; i < 101; i++ {
+		x := i
+		// nolint:errcheck
+		pool.Add(context.TODO(), background.NewJob("test", func(context.Context) error {
+			ch <- x
+			return nil
+		}))
+	}
+
+	go func() {
+		<-time.After(time.Millisecond * 50)
+		close(ch)
+		pool.Close()
+	}()
+
+	sum := 0
+	for n := range ch {
+		numbers = append(numbers, n)
+		sum += n
+	}
+	assert.Len(t, numbers, 100)
+	assert.Equal(t, 5050, sum)
+}

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,0 +1,19 @@
+package random
+
+import (
+	"math/rand"
+	"time"
+)
+
+// nolint: gochecknoinits
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func String(length int, alphabet string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = alphabet[rand.Int63()%int64(len(alphabet))] // nolint:gosec
+	}
+	return string(b)
+}

--- a/pkg/url/hasher/interface.go
+++ b/pkg/url/hasher/interface.go
@@ -1,5 +1,0 @@
-package hasher
-
-type Hasher interface {
-	Hash(string) string
-}

--- a/pkg/url/hasher/naive_test.go
+++ b/pkg/url/hasher/naive_test.go
@@ -14,21 +14,17 @@ func TestURLWithSha256(t *testing.T) {
 		want string
 	}{
 		{
-			name: "practicum",
 			URL:  "https://practicum.yandex.ru/",
 			want: "42b3e75",
 		},
 		{
-			name: "go.dev",
 			URL:  "https://go.dev/",
 			want: "ba6e07b",
 		},
 	}
 	theHasher := hasher.NewNaiveHasher()
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			val := theHasher.Hash(tt.URL)
-			assert.Equal(t, tt.want, val)
-		})
+		val := theHasher.Hash(tt.URL)
+		assert.Equal(t, tt.want, val)
 	}
 }

--- a/pkg/url/shortener/interface.go
+++ b/pkg/url/shortener/interface.go
@@ -1,0 +1,5 @@
+package shortener
+
+type Shortener interface {
+	Shorten(string) string
+}

--- a/pkg/url/shortener/rand.go
+++ b/pkg/url/shortener/rand.go
@@ -1,0 +1,18 @@
+package shortener
+
+import (
+	"github.com/sergeii/practikum-go-url-shortener/pkg/random"
+)
+
+type RandShortener struct{}
+
+const randLength = 11
+const alphabet = "-_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func NewRandShortener() *RandShortener {
+	return &RandShortener{}
+}
+
+func (h RandShortener) Shorten(s string) string {
+	return random.String(randLength, alphabet)
+}

--- a/pkg/url/shortener/rand_test.go
+++ b/pkg/url/shortener/rand_test.go
@@ -1,0 +1,1 @@
+package shortener_test

--- a/pkg/url/shortener/sha.go
+++ b/pkg/url/shortener/sha.go
@@ -1,19 +1,19 @@
-package hasher
+package shortener
 
 import (
 	"crypto/sha256"
 	"encoding/hex"
 )
 
-type NaiveHasher struct{}
+type ShaShortener struct{}
 
 const shortHashLength = 7
 
-func NewNaiveHasher() *NaiveHasher {
-	return &NaiveHasher{}
+func NewShaShortener() *ShaShortener {
+	return &ShaShortener{}
 }
 
-func (h NaiveHasher) Hash(s string) string {
+func (h ShaShortener) Shorten(s string) string {
 	algo := sha256.New()
 	algo.Write([]byte(s))
 	longURLSha := hex.EncodeToString(algo.Sum(nil))

--- a/pkg/url/shortener/sha_test.go
+++ b/pkg/url/shortener/sha_test.go
@@ -1,13 +1,13 @@
-package hasher_test
+package shortener_test
 
 import (
 	"testing"
 
-	"github.com/sergeii/practikum-go-url-shortener/pkg/url/hasher"
+	"github.com/sergeii/practikum-go-url-shortener/pkg/url/shortener"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestURLWithSha256(t *testing.T) {
+func TestShaShortener(t *testing.T) {
 	tests := []struct {
 		name string
 		URL  string
@@ -22,9 +22,9 @@ func TestURLWithSha256(t *testing.T) {
 			want: "ba6e07b",
 		},
 	}
-	theHasher := hasher.NewNaiveHasher()
+	theShortener := shortener.NewShaShortener()
 	for _, tt := range tests {
-		val := theHasher.Hash(tt.URL)
+		val := theShortener.Shorten(tt.URL)
 		assert.Equal(t, tt.want, val)
 	}
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -26,11 +26,16 @@ CREATE TABLE IF NOT EXISTS urls (
     original_url TEXT NOT NULL,
     user_id TEXT NOT NULL,
     created_at timestamptz NOT NULL DEFAULT NOW(),
+    is_deleted boolean NOT NULL DEFAULT FALSE,
     CHECK (user_id <> '')
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS urls_original_url_uniq_idx ON urls (original_url);
 CREATE UNIQUE INDEX IF NOT EXISTS urls_short_id_uniq_idx ON urls (short_id);
+ALTER TABLE urls DROP CONSTRAINT IF EXISTS urls_short_id_uniq;
+ALTER TABLE urls ADD CONSTRAINT urls_short_id_uniq UNIQUE USING INDEX urls_short_id_uniq_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS urls_original_url_uniq_idx ON urls (original_url) WHERE is_deleted = false;
+
 CREATE INDEX IF NOT EXISTS urls_user_id_idx ON urls(user_id);
 `
 
@@ -51,12 +56,18 @@ func (backend DatabaseURLStorerBackend) Set(ctx context.Context, shortURLID, lon
 	err := backend.DB.QueryRow(
 		ctx,
 		"INSERT INTO urls (short_id, original_url, user_id) VALUES($1, $2, $3) "+
-			"ON CONFLICT DO NOTHING RETURNING id",
+			"ON CONFLICT (original_url) WHERE is_deleted = false DO NOTHING RETURNING id",
 		shortURLID, longURL, userID,
 	).Scan(&rowID)
 	if err != nil {
+		// при попытке сохранить уже сокращенный URL (и при этом не удаленный)
+		// получим конфликт, и строка не вставится, вернув нам ничего
+		// что мы и обрабатываем, доставая из бд ранее сохраненную ссылку, о которую столкнулся запрос
 		if errors.Is(err, pgx.ErrNoRows) {
-			actualShortID, _ := backend.getShortIDForURL(ctx, backend.DB, longURL)
+			actualShortID, recoveryErr := backend.getShortIDForURL(ctx, backend.DB, longURL)
+			if recoveryErr != nil {
+				return "", recoveryErr
+			}
 			return actualShortID, ErrURLAlreadyExists
 		}
 		return "", err
@@ -66,18 +77,21 @@ func (backend DatabaseURLStorerBackend) Set(ctx context.Context, shortURLID, lon
 
 func (backend DatabaseURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {
 	var longURL string
+	var isDeleted bool
 
 	ctx, cancel := context.WithTimeout(ctx, backend.timeout)
 	defer cancel()
 
-	err := backend.DB.QueryRow(ctx, "SELECT original_url FROM urls WHERE short_id = $1 LIMIT 1", shortURLID).Scan(&longURL)
-	if err != nil {
+	row := backend.DB.QueryRow(ctx, "SELECT original_url, is_deleted FROM urls WHERE short_id = $1", shortURLID)
+	if err := row.Scan(&longURL, &isDeleted); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return "", ErrURLNotFound
 		}
 		return "", err
 	}
-
+	if isDeleted {
+		return "", ErrURLIsDeleted
+	}
 	return longURL, nil
 }
 
@@ -87,7 +101,9 @@ func (backend DatabaseURLStorerBackend) GetURLsByUserID(ctx context.Context, use
 	ctx, cancel := context.WithTimeout(ctx, backend.timeout)
 	defer cancel()
 
-	rows, err := backend.DB.Query(ctx, "SELECT short_id, original_url FROM urls WHERE user_id = $1", userID)
+	rows, err := backend.DB.Query(
+		ctx, "SELECT short_id, original_url FROM urls WHERE user_id = $1 AND is_deleted = false", userID,
+	)
 	if err != nil {
 		log.Printf("failed to query urls of user %s due to %v\n", userID, err)
 		return nil, err
@@ -111,8 +127,38 @@ func (backend DatabaseURLStorerBackend) GetURLsByUserID(ctx context.Context, use
 	return items, nil
 }
 
+func (backend DatabaseURLStorerBackend) DeleteUserURLs(ctx context.Context, userID string, shortIDs ...string) error {
+	ctx, cancel := context.WithTimeout(ctx, backend.timeout)
+	defer cancel()
+
+	tx, err := backend.DB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func(ctx context.Context) {
+		err := tx.Rollback(ctx)
+		if err != nil {
+			log.Printf("failed to rollback transaction due to %v", err)
+		}
+	}(ctx)
+
+	prepSQL := "UPDATE urls SET is_deleted = true WHERE short_id = $1 AND user_id = $2"
+	if _, err := tx.Prepare(ctx, "batch-mark-deleted", prepSQL); err != nil {
+		return err
+	}
+	for _, shortID := range shortIDs {
+		if _, err = tx.Exec(ctx, "batch-mark-deleted", shortID, userID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
 func (backend DatabaseURLStorerBackend) SaveBatch(ctx context.Context, items []BatchItem) (map[string]string, error) {
 	var rowID int
+
+	ctx, cancel := context.WithTimeout(ctx, backend.timeout)
+	defer cancel()
 
 	tx, err := backend.DB.Begin(ctx)
 	if err != nil {
@@ -125,21 +171,21 @@ func (backend DatabaseURLStorerBackend) SaveBatch(ctx context.Context, items []B
 		}
 	}(ctx)
 
-	prepSQL := "INSERT INTO urls (short_id, original_url, user_id) VALUES($1,$2,$3) ON CONFLICT DO NOTHING RETURNING id"
-	if _, err := tx.Prepare(ctx, "batch", prepSQL); err != nil {
+	prepSQL := "INSERT INTO urls (short_id, original_url, user_id) VALUES($1,$2,$3) " +
+		"ON CONFLICT (original_url) WHERE is_deleted = false DO NOTHING RETURNING id"
+	if _, err := tx.Prepare(ctx, "batch-insert", prepSQL); err != nil {
 		return nil, err
 	}
-
 	result := make(map[string]string)
 	for _, item := range items {
-		err = tx.QueryRow(ctx, "batch", item.ShortID, item.LongURL, item.UserID).Scan(&rowID)
+		err = tx.QueryRow(ctx, "batch-insert", item.ShortID, item.LongURL, item.UserID).Scan(&rowID)
 		if err != nil {
 			// строка не записалась из-за конфликта - пытаемся получить идентификатор ранее сокращенной ссылки
 			if errors.Is(err, pgx.ErrNoRows) {
 				actualShortID, recoveryErr := backend.getShortIDForURL(ctx, tx, item.LongURL)
 				// не получилось разрешить конфликт - пропускаем ссылку
 				if recoveryErr != nil {
-					continue
+					return nil, recoveryErr
 				}
 				result[item.LongURL] = actualShortID
 			} else {
@@ -149,6 +195,7 @@ func (backend DatabaseURLStorerBackend) SaveBatch(ctx context.Context, items []B
 			result[item.LongURL] = item.ShortID
 		}
 	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
@@ -184,11 +231,8 @@ func (backend DatabaseURLStorerBackend) getShortIDForURL(ctx context.Context, co
 	var shortID string
 	ctx, cancel := context.WithTimeout(ctx, backend.timeout)
 	defer cancel()
-	err := conn.QueryRow(ctx, "SELECT short_id FROM urls WHERE original_url = $1", url).Scan(&shortID)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return "", ErrURLNotFound
-		}
+	row := conn.QueryRow(ctx, "SELECT short_id FROM urls WHERE original_url = $1 AND is_deleted = false", url)
+	if err := row.Scan(&shortID); err != nil {
 		return "", err
 	}
 	return shortID, nil

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -6,3 +6,4 @@ import (
 
 var ErrURLNotFound = errors.New("URL not found in the storage")
 var ErrURLAlreadyExists = errors.New("URL already exists in the storage")
+var ErrURLIsDeleted = errors.New("URL has been deleted")

--- a/storage/file.go
+++ b/storage/file.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sync"
 )
 
 type FileURLItem struct {
@@ -17,10 +18,13 @@ type FileURLItem struct {
 type FileURLStorerBackend struct {
 	filename string
 	cache    map[string]FileURLItem
+	created  map[string]string
+	mu       sync.RWMutex
 }
 
 func NewFileURLStorerBackend(filename string) (*FileURLStorerBackend, error) {
 	cache := make(map[string]FileURLItem)
+	created := make(map[string]string) // служебная мапа, хранящая ссылки в формате URL -> Short ID
 	// Считываем с диска записи, сохраненные ранее, и заполняем ими кэш,
 	// с которым мы и будем работать до завершения программы
 	file, err := os.OpenFile(filename, os.O_RDONLY, 0777)
@@ -43,17 +47,37 @@ func NewFileURLStorerBackend(filename string) (*FileURLStorerBackend, error) {
 				log.Printf("unable to populate Storage from %s due to %s\n", filename, err)
 				return nil, err
 			}
+		} else {
+			// заполняем обратную мапу URL -> ShortID для быстрого поиска дублей
+			for shortID, item := range cache {
+				created[item.LongURL] = shortID
+			}
 		}
 	}
-	return &FileURLStorerBackend{filename, cache}, nil
+	backend := FileURLStorerBackend{
+		filename: filename,
+		cache:    cache,
+		created:  created,
+	}
+	return &backend, nil
 }
 
-func (backend FileURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) (string, error) {
+func (backend *FileURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) (string, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	// Для консистентности с бд-бэкендом поддерживаем проверку на уникальность ссылок
+	existingID, exists := backend.created[longURL]
+	if exists {
+		return existingID, ErrURLAlreadyExists
+	}
 	backend.cache[shortURLID] = FileURLItem{longURL, userID}
+	backend.created[longURL] = shortURLID
 	return shortURLID, nil
 }
 
-func (backend FileURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {
+func (backend *FileURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
 	item, found := backend.cache[shortURLID]
 	if !found {
 		return "", ErrURLNotFound
@@ -61,7 +85,9 @@ func (backend FileURLStorerBackend) Get(ctx context.Context, shortURLID string) 
 	return item.LongURL, nil
 }
 
-func (backend FileURLStorerBackend) GetURLsByUserID(ctx context.Context, userID string) (map[string]string, error) {
+func (backend *FileURLStorerBackend) GetURLsByUserID(ctx context.Context, userID string) (map[string]string, error) {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
 	items := make(map[string]string)
 	if userID == "" {
 		return items, nil
@@ -74,22 +100,36 @@ func (backend FileURLStorerBackend) GetURLsByUserID(ctx context.Context, userID 
 	return items, nil
 }
 
-func (backend FileURLStorerBackend) SaveBatch(ctx context.Context, items []BatchItem) error {
+func (backend *FileURLStorerBackend) SaveBatch(ctx context.Context, items []BatchItem) (map[string]string, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	result := make(map[string]string)
 	for _, item := range items {
-		backend.cache[item.ShortID] = FileURLItem{item.LongURL, item.UserID}
+		// Проверяем на дубли
+		if val, exists := backend.created[item.LongURL]; exists {
+			result[item.LongURL] = val
+		} else {
+			backend.cache[item.ShortID] = FileURLItem{item.LongURL, item.UserID}
+			backend.created[item.LongURL] = item.ShortID
+			result[item.LongURL] = item.ShortID
+		}
 	}
+	return result, nil
+}
+
+func (backend *FileURLStorerBackend) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (backend FileURLStorerBackend) Ping(ctx context.Context) error {
-	return nil
+func (backend *FileURLStorerBackend) Cleanup() {
+	if err := os.Remove(backend.filename); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			panic(err)
+		}
+	}
 }
 
-func (backend FileURLStorerBackend) Cleanup() {
-	// do nothing
-}
-
-func (backend FileURLStorerBackend) Close() error {
+func (backend *FileURLStorerBackend) Close() error {
 	// Сохраняем на диск рабочий кэш со ссылками,
 	// который будет использован при следующем старте программы
 	file, err := os.OpenFile(backend.filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)

--- a/storage/file_test.go
+++ b/storage/file_test.go
@@ -158,7 +158,7 @@ func TestFileStorageIsAbleToStartWithoutFile(t *testing.T) {
 
 	f, _ := os.Open(filename)
 	defer f.Close()
-	savedItems := make(map[string]map[string]string)
+	savedItems := make(map[string]map[string]interface{})
 	err = json.NewDecoder(f).Decode(&savedItems)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://go.dev/", savedItems["foo"]["LongURL"])
@@ -176,7 +176,7 @@ func TestFileStorageIsAbleToStartWithEmptyFile(t *testing.T) {
 
 	f, _ = os.Open(f.Name())
 	defer f.Close()
-	savedItems := make(map[string]map[string]string)
+	savedItems := make(map[string]map[string]interface{})
 	err = json.NewDecoder(f).Decode(&savedItems)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://go.dev/", savedItems["foo"]["LongURL"])
@@ -213,4 +213,10 @@ func TestFileStorageDoesNotEscapeHTMLChars(t *testing.T) {
 	defer f.Close()
 	json.NewDecoder(f).Decode(&savedItems) // nolint:errcheck
 	assert.Equal(t, "https://yandex.ru/search/?lr=213&text=golang", savedItems["foo"]["LongURL"])
+}
+
+func TestFileStoragePing(t *testing.T) {
+	theStorage, closeFunc := getTestFileStorage()
+	defer closeFunc()
+	assert.Nil(t, theStorage.Ping(context.TODO()))
 }

--- a/storage/file_test.go
+++ b/storage/file_test.go
@@ -72,10 +72,10 @@ func TestGetURLFromFileStorage(t *testing.T) {
 	ctx := context.TODO()
 	theStorage, closeFunc := getTestFileStorage()
 	defer closeFunc()
+	theStorage.Set(ctx, "foo", "https://practicum.yandex.ru/", "") // nolint: errcheck
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			theStorage.Set(ctx, "foo", "https://practicum.yandex.ru/", "") // nolint: errcheck
 			longURL, err := theStorage.Get(ctx, tt.key)
 			if tt.isErr {
 				assert.Error(t, err)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -6,6 +6,7 @@ type URLStorer interface {
 	Set(context.Context, string, string, string) (string, error)
 	Get(context.Context, string) (string, error)
 	GetURLsByUserID(context.Context, string) (map[string]string, error)
+	DeleteUserURLs(context.Context, string, ...string) error
 	SaveBatch(context.Context, []BatchItem) (map[string]string, error)
 	Ping(context.Context) error
 	Cleanup()

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -6,7 +6,7 @@ type URLStorer interface {
 	Set(context.Context, string, string, string) (string, error)
 	Get(context.Context, string) (string, error)
 	GetURLsByUserID(context.Context, string) (map[string]string, error)
-	SaveBatch(context.Context, []BatchItem) error
+	SaveBatch(context.Context, []BatchItem) (map[string]string, error)
 	Ping(context.Context) error
 	Cleanup()
 	Close() error

--- a/storage/locmem.go
+++ b/storage/locmem.go
@@ -1,6 +1,9 @@
 package storage
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type LocURLItem struct {
 	LongURL string
@@ -9,19 +12,35 @@ type LocURLItem struct {
 
 type LocmemURLStorerBackend struct {
 	Storage map[string]LocURLItem
+	created map[string]string
+	mu      sync.RWMutex
 }
 
 func NewLocmemURLStorerBackend() *LocmemURLStorerBackend {
 	storage := make(map[string]LocURLItem)
-	return &LocmemURLStorerBackend{Storage: storage}
+	created := make(map[string]string)
+	return &LocmemURLStorerBackend{
+		Storage: storage,
+		created: created,
+	}
 }
 
-func (backend LocmemURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) (string, error) {
+func (backend *LocmemURLStorerBackend) Set(ctx context.Context, shortURLID, longURL, userID string) (string, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	// Для консистентности с бд-бэкендом поддерживаем проверку на уникальность ссылок
+	existingID, exists := backend.created[longURL]
+	if exists {
+		return existingID, ErrURLAlreadyExists
+	}
 	backend.Storage[shortURLID] = LocURLItem{longURL, userID}
+	backend.created[longURL] = shortURLID
 	return shortURLID, nil
 }
 
-func (backend LocmemURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {
+func (backend *LocmemURLStorerBackend) Get(ctx context.Context, shortURLID string) (string, error) {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
 	item, found := backend.Storage[shortURLID]
 	if !found {
 		return "", ErrURLNotFound
@@ -29,7 +48,9 @@ func (backend LocmemURLStorerBackend) Get(ctx context.Context, shortURLID string
 	return item.LongURL, nil
 }
 
-func (backend LocmemURLStorerBackend) GetURLsByUserID(ctx context.Context, userID string) (map[string]string, error) {
+func (backend *LocmemURLStorerBackend) GetURLsByUserID(ctx context.Context, userID string) (map[string]string, error) {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
 	items := make(map[string]string)
 	if userID == "" {
 		return items, nil
@@ -42,22 +63,32 @@ func (backend LocmemURLStorerBackend) GetURLsByUserID(ctx context.Context, userI
 	return items, nil
 }
 
-func (backend LocmemURLStorerBackend) SaveBatch(ctx context.Context, items []BatchItem) error {
+func (backend *LocmemURLStorerBackend) SaveBatch(ctx context.Context, items []BatchItem) (map[string]string, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	result := make(map[string]string)
 	for _, item := range items {
-		backend.Storage[item.ShortID] = LocURLItem{item.LongURL, item.UserID}
+		// Проверяем на дубли
+		if val, exists := backend.created[item.LongURL]; exists {
+			result[item.LongURL] = val
+		} else {
+			backend.Storage[item.ShortID] = LocURLItem{item.LongURL, item.UserID}
+			backend.created[item.LongURL] = item.ShortID
+			result[item.LongURL] = item.ShortID
+		}
 	}
+	return result, nil
+}
+
+func (backend *LocmemURLStorerBackend) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (backend LocmemURLStorerBackend) Ping(ctx context.Context) error {
-	return nil
+func (backend *LocmemURLStorerBackend) Cleanup() {
+	backend.Storage = make(map[string]LocURLItem)
 }
 
-func (backend LocmemURLStorerBackend) Cleanup() {
-	// do nothing
-}
-
-func (backend LocmemURLStorerBackend) Close() error {
+func (backend *LocmemURLStorerBackend) Close() error {
 	// do nothing
 	return nil
 }

--- a/storage/locmem_test.go
+++ b/storage/locmem_test.go
@@ -92,3 +92,8 @@ func TestGetUserURLsFromLocmemStorage(t *testing.T) {
 	emptyUserItems, _ := theStorage.GetURLsByUserID(ctx, "")
 	assert.Len(t, emptyUserItems, 0)
 }
+
+func TestLocmemStoragePing(t *testing.T) {
+	theStorage := storage.NewLocmemURLStorerBackend()
+	assert.Nil(t, theStorage.Ping(context.TODO()))
+}


### PR DESCRIPTION
* обновлена схема github actions для тестов из шаблона https://github.com/yandex-praktikum/go-musthave-shortener-tpl
* добавлена поддержка массового удаления ссылок, которое происходит в фоне
* логика бэкендов хранилищ теперь потокобезопасна благодаря использованию мютексов
* изменена механика генерации коротких идентификаторов. Теперь это рандомная строка, а не детерменированная в виде sha256 от оригинального урла, как было ранее